### PR TITLE
feat(rustfs): add rustfs-container for NixOS systemd-nspawn

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,11 @@
       home-manager.inputs.nixpkgs.follows = "nixpkgs"; # Use system packages list where available
       microvm.url = "github:astro/microvm.nix";
       nixpkgs.url = "nixpkgs/nixos-unstable";
+      rustfs.url = "github:rustfs/rustfs-flake";
+      rustfs.inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    outputs = {self, nixpkgs, microvm, ...}@inputs:
+    outputs = {self, nixpkgs, microvm, rustfs, ...}@inputs:
       let
         lib = nixpkgs.lib;
         system = "x86_64-linux";

--- a/hosts/odroid/configuration.nix
+++ b/hosts/odroid/configuration.nix
@@ -24,6 +24,7 @@
       ../../nix-containers/redis-container.nix
       ../../nix-containers/ntfy-sh-container.nix
       ../../nix-containers/romm-container.nix
+      ../../nix-containers/rustfs-container.nix
     ];
 
   # Bootloader.
@@ -605,6 +606,15 @@
     tailNet = "tail5bbc4.ts.net";
     containerName = "ntfy-sh";
     ipAddress = "192.168.100.41";
+  };
+
+  services.rustfs-container = {
+    enable = true;
+    tailNet = "tail5bbc4.ts.net";
+    containerName = "rustfs";
+    ipAddress = "192.168.100.40";
+    accessKeyFile = "/mnt/data/rustfs/secrets/access-key";
+    secretKeyFile = "/mnt/data/rustfs/secrets/secret-key";
   };
 
   # This value determines the NixOS release from which the default

--- a/hosts/odroid/configuration.nix
+++ b/hosts/odroid/configuration.nix
@@ -615,6 +615,7 @@
     ipAddress = "192.168.100.40";
     accessKeyFile = "/mnt/data/rustfs/secrets/access-key";
     secretKeyFile = "/mnt/data/rustfs/secrets/secret-key";
+    prometheusTokenFile = "/mnt/data/rustfs/secrets/prometheus-token";
   };
 
   # This value determines the NixOS release from which the default

--- a/nix-containers/prometheus-container.nix
+++ b/nix-containers/prometheus-container.nix
@@ -40,6 +40,10 @@ in {
         "/var/lib/prometheus" = {
           hostPath = "/mnt/data/prometheus";
         };
+        "/etc/rustfs-prom-token" = {
+          hostPath = "/mnt/data/rustfs/secrets/prometheus-token";
+          isReadOnly = true;
+        };
       };
 
 
@@ -116,6 +120,18 @@ in {
                   "vectordb.${cfg.tailNet}:5252"
                 ];
               }];
+            }
+            {
+              job_name = "rustfs";
+              bearer_token_file = "/etc/rustfs-prom-token";
+              scheme = "https";
+              scrape_interval = "1m";
+              static_configs = [{
+                targets = [ "rustfs.${cfg.tailNet}:443" ];
+              }];
+              tls_config = {
+                insecure_skip_verify = false;
+              };
             }
           ];
         };

--- a/nix-containers/rustfs-container.nix
+++ b/nix-containers/rustfs-container.nix
@@ -31,6 +31,11 @@ in {
       default = "/mnt/data/rustfs/secrets/secret-key";
       description = "Path to the secret key file on the host";
     };
+    prometheusTokenFile = mkOption {
+      type = types.path;
+      default = "/mnt/data/rustfs/secrets/prometheus-token";
+      description = "Path to the prometheus bearer token file on the host";
+    };
   };
 
   config = mkIf cfg.enable {

--- a/nix-containers/rustfs-container.nix
+++ b/nix-containers/rustfs-container.nix
@@ -1,0 +1,131 @@
+{ lib, pkgs, config, ... }:
+with lib;
+let
+  cfg = config.services.rustfs-container;
+in {
+  options.services.rustfs-container = {
+    enable = mkEnableOption "Enable rustfs container service";
+    tailNet = mkOption {
+      type = types.str;
+      default = "tail1abc2.ts.net";
+    };
+    containerName = mkOption {
+      type = types.str;
+      default = "rustfs";
+    };
+    ipAddress = mkOption {
+      type = types.str;
+      default = "192.168.100.40";
+    };
+    hostAddress = mkOption {
+      type = types.str;
+      default = "192.168.100.10";
+    };
+    accessKeyFile = mkOption {
+      type = types.path;
+      default = "/mnt/data/rustfs/secrets/access-key";
+      description = "Path to the access key file on the host";
+    };
+    secretKeyFile = mkOption {
+      type = types.path;
+      default = "/mnt/data/rustfs/secrets/secret-key";
+      description = "Path to the secret key file on the host";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Import rustfs flake module
+    imports = [
+      (builtins.getFlake "github:rustfs/rustfs-flake").nixosModules.rustfs
+    ];
+
+    containers.${cfg.containerName} = {
+      autoStart = true;
+      enableTun = true;
+      privateNetwork = true;
+      hostAddress = "${cfg.hostAddress}";
+      localAddress = "${cfg.ipAddress}";
+      bindMounts = {
+        "/.env/.${cfg.containerName}.env" = {
+          hostPath = "/mnt/data/${cfg.containerName}/.env/${cfg.containerName}.env";
+          isReadOnly = true;
+        };
+        "/${cfg.containerName}/data" = {
+          hostPath = "/mnt/data/${cfg.containerName}/data";
+          isReadOnly = false;
+        };
+        "/${cfg.containerName}/secrets" = {
+          hostPath = "/mnt/data/${cfg.containerName}/secrets";
+          isReadOnly = true;
+        };
+      };
+
+      extraFlags = [ "--private-users-ownership=chown" ];
+      additionalCapabilities = [
+        ''all" --system-call-filter="add_key keyctl bpf" --capability="all''
+      ];
+      allowedDevices = [
+        { node = "/dev/fuse"; modifier = "rwm"; }
+        { node = "/dev/mapper/control"; modifier = "rw"; }
+        { node = "/dev/console"; modifier = "rwm"; }
+      ];
+      bindMounts.fuse = {
+        hostPath = "/dev/fuse";
+        mountPoint = "/dev/fuse";
+        isReadOnly = false;
+      };
+
+      config = { pkgs, ... }: {
+        boot.isContainer = true;
+
+        environment.systemPackages = with pkgs; [
+          vim
+          wget
+          iputils
+          git
+          bind
+          jq
+          zip
+          openssl
+        ];
+
+        networking.nameservers = [ "100.100.100.100" "1.1.1.1" ];
+        networking.useHostResolvConf = false;
+
+        services.journald.extraConfig = "SystemMaxUse=100M";
+
+        # rustfs service - native NixOS service from rustfs-flake
+        services.rustfs = {
+          enable = true;
+          volumes = "/${cfg.containerName}/data";
+          address = ":9000";
+          consoleEnable = true;
+          consoleAddress = "127.0.0.1:9001";
+          logLevel = "info";
+          # Use secrets from bind-mounted directory
+          accessKeyFile = "/${cfg.containerName}/secrets/access-key";
+          secretKeyFile = "/${cfg.containerName}/secrets/secret-key";
+        };
+
+        services.tailscale = {
+          enable = true;
+          permitCertUid = "caddy";
+        };
+
+        services.caddy = {
+          enable = true;
+          extraConfig = ''
+            ${cfg.containerName}.${cfg.tailNet} {
+              reverse_proxy ${cfg.ipAddress}:9000
+            }
+          '';
+        };
+
+        # open https port
+        networking.firewall.allowedTCPPorts = [ 443 9000 ];
+
+        system.stateVersion = "25.05";
+      };
+    };
+  };
+}


### PR DESCRIPTION
Adds rustfs-container.nix — a new NixOS container module for running RustFS inside a systemd-nspawn container on Odroid.

Changes:
- nix-containers/rustfs-container.nix: new container module (rustfs-flake nixosModule import, Caddy proxy on rustfs.tail5bbc4.ts.net:443, IP 192.168.100.40)
- flake.nix: added rustfs input
- hosts/odroid/configuration.nix: imports and enables the container

Secrets required at /mnt/data/rustfs/secrets/: access-key, secret-key