### PR TITLE
fix: pass rustfs package as rustfsPkg via specialArgs, not via inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,8 @@
           odroid = lib.nixosSystem {
             inherit system;
             specialArgs = {
-              inherit inputs rustfs;
+              inherit inputs;
+              rustfsPkg = rustfs;
               userName = "ewt";
               userEmail = "36795362+dverdonschot@users.noreply.github.com";
             };

--- a/hosts/odroid/configuration.nix
+++ b/hosts/odroid/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running ‘nixos-help’).
 
-{ config, pkgs, ... }:
+{ config, pkgs, lib, rustfsPkg, ... }:
 
 {
   imports =
@@ -616,7 +616,7 @@
     accessKeyFile = "/mnt/data/rustfs/secrets/access-key";
     secretKeyFile = "/mnt/data/rustfs/secrets/secret-key";
     prometheusTokenFile = "/mnt/data/rustfs/secrets/prometheus-token";
-    package = rustfs;
+    package = rustfsPkg;
   };
 
   # This value determines the NixOS release from which the default


### PR DESCRIPTION
specialArgs must not contain the full flake inputs attrset when passed to a module - only specific packages/values needed. Use rustfsPkg instead.